### PR TITLE
自動更新機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'pry-rails'
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~> 3.5'
   gem 'rails-controller-testing'
@@ -62,3 +63,4 @@ gem "font-awesome-rails"
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'rb-readline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -124,6 +125,11 @@ GEM
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.1)
     rack (2.0.6)
     rack-test (0.6.3)
@@ -159,6 +165,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rb-readline (0.5.5)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -245,9 +252,11 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing
+  rb-readline
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   spring

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -46,4 +46,32 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     })
   });
+
+   var reloadMessages = function() {
+    if(location.href.match(/\/groups\/\d+\/messages/)){
+       if($('.message')[0]){
+         var last_message_id = $('.message:last').data('message-id');
+       }else{
+         var last_message_id = 0;
+       }
+      $.ajax({
+        url: 'api/messages',
+        type: 'GET',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        var insertHTML = '';
+        messages.forEach(function(message){
+        insertHTML = buildHTML(message);
+      $('.messages').append(insertHTML);
+      $('.messages').animate({scrollTop: $(".messages")[0].scrollHeight}, 'fast');
+     })
+    })
+    .fail(function() {
+      alert('自動更新に失敗しました');
+    })
+   };
+  }
+   setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -49,11 +49,9 @@ $(function(){
 
    var reloadMessages = function() {
     if(location.href.match(/\/groups\/\d+\/messages/)){
-       if($('.message')[0]){
-         var last_message_id = $('.message:last').data('message-id');
-       }else{
-         var last_message_id = 0;
-       }
+      
+      var last_message_id = ($('.message')[0]) ? $('.message:last').data('message-id') : 0 ;
+      
       $.ajax({
         url: 'api/messages',
         type: 'GET',
@@ -63,15 +61,15 @@ $(function(){
       .done(function(messages) {
         var insertHTML = '';
         messages.forEach(function(message){
-        insertHTML = buildHTML(message);
-      $('.messages').append(insertHTML);
-      $('.messages').animate({scrollTop: $(".messages")[0].scrollHeight}, 'fast');
-     })
-    })
-    .fail(function() {
-      alert('自動更新に失敗しました');
-    })
-   };
-  }
+          insertHTML = buildHTML(message);
+          $('.messages').append(insertHTML);
+          $('.messages').animate({scrollTop: $(".messages")[0].scrollHeight}, 'fast');
+        })
+      })
+      .fail(function() {
+        alert('自動更新に失敗しました');
+      })
+    };
+   }
    setInterval(reloadMessages, 5000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+
+  def index
+    @group = Group.find(params[:group_id])
+    @new_messages = @group.messages.includes(:user).where('id > ?', params[:id])
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,19 +3,17 @@ class GroupsController < ApplicationController
   before_action :find_group, only: [:edit, :update]
 
  def index
-
  end
 
  def new
-  @group = Group.new
-  @group.users << current_user
+  @group = Group.new  
  end
 
  def create
   @group = Group.new(group_params)
-
+  @group.users << current_user
   if @group.save
-    redirect_to root_path ,notice: 'グループを作成しました'
+    redirect_to root_path, notice: 'グループを作成しました'
   else
     render :new
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,11 +3,7 @@ class MessagesController < ApplicationController
   
   def index
     @message = Message.new
-    @messages = @group.messages.includes(:user)
-    respond_to do |format|
-      format.html
-      format.json {@new_messages = @messages.where('id > ?',params[:id]) }
-    end
+    @messages = @group.messages.includes(:user)  
   end
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,4 @@ class User < ApplicationRecord
   has_many :messages
   has_many :group_users
   has_many :groups, through: :group_users
-  has_many :messages
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @new_messages.each do |message|
+  json.id message.id
+  json.body message.body
+  json.user_name message.user.name
+  json.image message.image.url
+  json.data message.created_at.strftime("%Y/%m/%d %H:%M")
+end

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,7 +1,0 @@
-json.array! @new_messages.each do |message|
-  json.id message.id
-  json.body message.body
-  json.user_name message.user.name
-  json.image message.image
-  json.data message.created_at.strftime("%Y/%m/%d %H:%M")
-end

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -18,4 +18,3 @@
           .group__message
             = group.show_last_message
       
-        

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
 # WHAT
ChatSpaceでメッセージ画面が自動で更新されることで、自分以外のユーザーが送信したメッセージも更新時に表示されるようにする

# WHY
非同期通信で画面に投稿したメッセージが表示されますが、別のユーザーが別の画面から投稿したメッセージはリロードしなければ表示されないため。

